### PR TITLE
Fix unit test issue by calling atfork()

### DIFF
--- a/lib/pyDHE/unitTests/DHEtest.py
+++ b/lib/pyDHE/unitTests/DHEtest.py
@@ -1,6 +1,7 @@
 import unittest
 import socket
 import os
+from Crypto.Random import atfork
 from Crypto.Util.number import bytes_to_long, long_to_bytes
 
 import pyDHE
@@ -29,6 +30,7 @@ class DiffieHellmanTests(unittest.TestCase):
         port = server.getsockname()[1]
 
         pid = os.fork()
+        atfork()
 
         # child process - aka, the server
         if pid == 0:


### PR DESCRIPTION
Fixes Python 2.7.x specific unit test issue:

```
$ python2 DHEtest.py 
..F..........
======================================================================
FAIL: test_negotiate (__main__.DiffieHellmanTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "DHEtest.py", line 46, in test_negotiate
    alice = pyDHE.new(group)
  File "/home/vesche/code/pyDHE_bak/lib/pyDHE/__init__.py", line 180, in new
    return DHE(*args, **kwargs)
  File "/home/vesche/code/pyDHE_bak/lib/pyDHE/__init__.py", line 154, in __init__
    self.a = randInt(1, self.p - 1)
  File "build/bdist.linux-x86_64/egg/Crypto/Random/random.py", line 91, in randint
    N = self.randrange(a, b+1)
  File "build/bdist.linux-x86_64/egg/Crypto/Random/random.py", line 83, in randrange
    r = self.getrandbits(size(num_choices))
  File "build/bdist.linux-x86_64/egg/Crypto/Random/random.py", line 51, in getrandbits
    return mask & bytes_to_long(self._randfunc(ceil_div(k, 8)))
  File "build/bdist.linux-x86_64/egg/Crypto/Random/_UserFriendlyRNG.py", line 202, in read
    return self._singleton.read(bytes)
  File "build/bdist.linux-x86_64/egg/Crypto/Random/_UserFriendlyRNG.py", line 178, in read
    return _UserFriendlyRNG.read(self, bytes)
  File "build/bdist.linux-x86_64/egg/Crypto/Random/_UserFriendlyRNG.py", line 137, in read
    self._check_pid()
  File "build/bdist.linux-x86_64/egg/Crypto/Random/_UserFriendlyRNG.py", line 153, in _check_pid
    raise AssertionError("PID check failed. RNG must be re-initialized after fork(). Hint: Try Random.atfork()")
AssertionError: PID check failed. RNG must be re-initialized after fork(). Hint: Try Random.atfork()

----------------------------------------------------------------------
Ran 13 tests in 25.859s

FAILED (failures=1)
...........
----------------------------------------------------------------------
Ran 13 tests in 25.916s

OK
```

Apparently:
```
>>> from Crypto.Random import atfork
>>> print(atfork.__doc__)
Call this whenever you call os.fork()
```
So, that's what I added :smiley: 

Also, everything works with Python 2 & 3 :+1: fyi:
```
$ python2 DHEtest.py 
.............
----------------------------------------------------------------------
Ran 13 tests in 26.357s

OK
...........
----------------------------------------------------------------------
Ran 13 tests in 26.385s

OK
$ python3 DHEtest.py 
.............
----------------------------------------------------------------------
Ran 13 tests in 23.778s

OK
...........
----------------------------------------------------------------------
Ran 13 tests in 23.800s

OK
```